### PR TITLE
Patch eventNameWithId

### DIFF
--- a/src/jquery.asScrollable.js
+++ b/src/jquery.asScrollable.js
@@ -459,7 +459,9 @@
 
         eventNameWithId: function(events) {
             if (typeof events !== 'string' || events === '') {
-                return this.options.namespace + '-' + this.instanceId;
+                // patch by adding a '.' in front, so that event can be
+                // unbind properly later
+                return '.' + this.options.namespace + '-' + this.instanceId;
             }
 
             events = events.split(' ');


### PR DESCRIPTION
update `eventNameWithId` to ensure events are unbind properly when `asScrollable.destory` is called
